### PR TITLE
feat: build for arm64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -95,6 +95,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
 
       # Output the image tags for easy copying
       - name: Output image tags


### PR DESCRIPTION
This PR is to ensure multi-architecture support for the Docker image when it is built. Right now `arm64` (Apple silicon) is not supported:

<img width="1152" height="175" alt="image" src="https://github.com/user-attachments/assets/174b6a9d-cccb-49f9-bf4d-85ed3b5b4483" />
